### PR TITLE
Specify gym as a requirement for atari-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(name='atari-py',
       packages=['atari_py'],
       package_data={'atari_py': package_data},
       cmdclass={'build': Build},
-      install_requires=['numpy', 'six', 'gym'],
+      install_requires=['numpy', 'cmake', 'six', 'gym'],
       tests_require=['nose2']
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(name='atari-py',
       packages=['atari_py'],
       package_data={'atari_py': package_data},
       cmdclass={'build': Build},
-      install_requires=['numpy', 'six'],
+      install_requires=['numpy', 'six', 'gym'],
       tests_require=['nose2']
 )


### PR DESCRIPTION
Not doing this can cause problems when packages depend on both gym and atari-py, if atari-py gets installed first.