### PR TITLE
Don't override atari-py when testing against gym

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ function pre_build {
 }
 
 function run_tests {
-    pip install gym[atari]
+    pip install gym
     python -c "import gym; gym.make('Pong-v4')"
     pip install pytest
     pytest --pyargs atari_py.tests


### PR DESCRIPTION
This is a continuation of the discussion from #49.

If the current version of `atari-py` doesn't conform to the semver of `gym[atari]` the package intended on being tested will be uninstalled. Removing `gym` as a test dependency might not be worth it if you intend to test against a ROM (as gym distributes the ROMs). Perhaps one solution to the problem is installing `gym` without the `atari` suffix. In the CI tests you'll have `atari-py` installed before running the smoke test.