### PR TITLE
patch road runner rom to get correct one

### DIFF
--- a/atari_py/ale_interface/md5.txt
+++ b/atari_py/ale_interface/md5.txt
@@ -58,7 +58,6 @@ ef3a4f64b6494ba770862768caf04b86 private_eye.bin
 484b0076816a104875e00467d431c2d2 qbert.bin
 393948436d1f4cc3192410bb918f9724 riverraid.bin
 2bd00beefdb424fa39931a75e890695d road_runner.bin
-ce5cc62608be2cd3ed8abd844efb8919 road_runner.bin
 4f618c2429138e0280969193ed6c107e robotank.bin
 240bfbac5163af4df5ae713985386f92 seaquest.bin
 dd0cbe5351551a538414fb9e37fc56e8 sir_lancelot.bin

--- a/atari_py/import_roms.py
+++ b/atari_py/import_roms.py
@@ -3,6 +3,7 @@ import hashlib
 import shutil
 import zipfile
 import argparse
+import io
 
 from .games import get_games_dir
 
@@ -45,10 +46,23 @@ def import_roms(dirpath="."):
 
     def save_if_matches(f):
         hexdigest = _calc_md5(f)
+        if hexdigest == "ce5cc62608be2cd3ed8abd844efb8919":
+            # the ALE version of road_runner.bin is not easily available
+            # patch this file instead to match the correct data
+            delta = {4090: 216, 4091: 111, 4092: 216, 4093: 111, 4094: 216, 4095: 111, 8186: 18, 8187: 43, 8188: -216, 8189: 49, 8190: -216, 8191: 49, 12281: 234, 12282: 18, 12283: 11, 12284: -216, 12285: 17, 12286: -216, 12287: 17, 16378: 18, 16379: -21, 16380: -216, 16381: -15, 16382: -216, 16383: -15}
+            f.seek(0)
+            data = bytearray(f.read())
+            for index, offset in delta.items():
+                data[index] += offset
+            name = f"patched version of {f.name}"
+            f = io.BytesIO(bytes(data))
+            f.name = name
+            hexdigest = _calc_md5(f)
+
         if hexdigest in md5s and hexdigest not in copied_md5s:
             copied_md5s.add(hexdigest)
             rom_path = md5s[hexdigest]
-            print(f"copying {os.path.basename(rom_path)} from {f.name}")
+            print(f"copying {os.path.basename(rom_path)} from {f.name} to {rom_path}")
             os.makedirs(os.path.dirname(rom_path), exist_ok=True)
             f.seek(0)
             with open(rom_path, "wb") as out_f:


### PR DESCRIPTION
The roms files were are recommending for `import_roms` doesn't have the canonical copy of `road_runner.bin`, patch the closest version to be correct.